### PR TITLE
Try to fix master by updating Holocron

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
     - name: Build
       run: holocron run compile
     - name: Deploy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,3 +23,9 @@ jobs:
         python -m pip install pre-commit
 
         pre-commit run --all-files --show-diff-on-failure
+    - name: holocron
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+
+        holocron run compile

--- a/.holocron.yml
+++ b/.holocron.yml
@@ -9,7 +9,6 @@ pipes:
     - name: import-processors
       imports:
         - episodes = episodes:process
-        - chain = holocron._processors.chain:process
         - welcome = welcome:process
       from_: "%(here)s/processors"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests >= 2.22.0
 # We use reimplemented version of Holocron from master branch because it
 # has not been released yet. Unreleased version feels like a completely
 # brand new software, so we have no other choice but patiently wait. 8)
-git+https://github.com/ikalnytskyi/holocron.git@732784a
+git+https://github.com/ikalnytskyi/holocron.git@32906d91fbf4a32739fcd22be63aa7f8a7bfdd5c


### PR DESCRIPTION
Apparently there's some issues with pip installing poetry sources (not
wheels or tarballs). Hopefully, it should be fixed in Holocron master.
Let's update it.

Also, in order to prevent such issues in the future, let's ensure that
the site can be built on every PR.