### PR TITLE
Add itunes:author tag

### DIFF
--- a/.holocron.yml
+++ b/.holocron.yml
@@ -41,6 +41,8 @@ pipes:
           description:
             $ref: 'metadata:#/description'
           language: uk
+          itunes_author:
+            $ref: metadata:#/authors
           itunes_subtitle:
             $ref: 'metadata:#/description'
           itunes_category:


### PR DESCRIPTION
According to some validator site, iTunes rejects feeds without author
tag.